### PR TITLE
fix: return blocked field for key

### DIFF
--- a/src/server/routes/key/get-key.ts
+++ b/src/server/routes/key/get-key.ts
@@ -25,6 +25,7 @@ const outputSchema = v.nullable(
     maxBudget: v.nullable(v.number()),
     budgetDuration: v.nullable(v.string()),
     budgetResetAt: v.nullable(v.string()),
+    blocked: v.nullable(v.boolean()),
     createdAt: v.string(),
   }),
 );
@@ -75,6 +76,7 @@ export const getKey = createRouteResolver({
         maxBudget: key.maxBudget,
         budgetDuration: key.budgetDuration,
         budgetResetAt: key.budgetResetAt,
+        blocked: key.blocked,
         createdAt: key.createdAt,
       };
     }

--- a/src/services/litellm.ts
+++ b/src/services/litellm.ts
@@ -245,6 +245,7 @@ export class Litellm {
             max_budget: number | null;
             budget_duration: string | null;
             budget_reset_at: string | null;
+            blocked: boolean | null;
             created_at: string;
           };
         },
@@ -280,6 +281,7 @@ export class Litellm {
       maxBudget: keyInfo.info.max_budget,
       budgetDuration: keyInfo.info.budget_duration,
       budgetResetAt: keyInfo.info.budget_reset_at,
+      blocked: keyInfo.info.blocked,
       createdAt: keyInfo.info.created_at,
     };
   }

--- a/src/types/litellm.ts
+++ b/src/types/litellm.ts
@@ -97,6 +97,7 @@ export type Key = {
   maxBudget: number | null;
   budgetDuration: string | null;
   budgetResetAt: string | null;
+  blocked: boolean | null;
   createdAt: string;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new field to key information responses indicating whether a key is blocked. This status is now visible when retrieving key details via the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->