### PR TITLE
fix: key metadata type

### DIFF
--- a/src/server/routes/key/get-key.ts
+++ b/src/server/routes/key/get-key.ts
@@ -28,7 +28,7 @@ const outputSchema = v.nullable(
     budgetResetAt: v.nullable(v.string()),
     blocked: v.nullable(v.boolean()),
     createdAt: v.string(),
-    metadata: v.record(v.string(), v.string()),
+    metadata: v.record(v.string(), v.unknown()),
   }),
 );
 

--- a/src/server/routes/key/list-keys.ts
+++ b/src/server/routes/key/list-keys.ts
@@ -43,7 +43,7 @@ const outputSchema = v.object({
       budgetResetAt: v.nullable(v.string()),
       blocked: v.nullable(v.boolean()),
       createdAt: v.string(),
-      metadata: v.record(v.string(), v.string()),
+      metadata: v.record(v.string(), v.unknown()),
     }),
   ),
   totalKeys: v.number(),

--- a/src/types/litellm-api-client.ts
+++ b/src/types/litellm-api-client.ts
@@ -72,7 +72,7 @@ export type Key = {
   metadata: KeyMetadata;
 };
 
-export type KeyMetadata = Record<string, string>; // TODO: Maybe `Record<string, unknown>` or a more specific type
+export type KeyMetadata = Record<string, unknown>; // TODO: Maybe a more specific type
 
 export type ListKeysParams = {
   userId: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Key metadata now supports any value type (not just strings) across the Get Key and List Keys endpoints, enabling richer, structured metadata.
  - API client typings updated to reflect the expanded metadata value types.

- Impact
  - Clients expecting metadata values as strings may need to adjust parsing/validation.
  - No changes to request inputs or other response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->