### PR TITLE
fix: transform key to hash

### DIFF
--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawnSync } from 'child_process';
 import { logger } from './services/logger';
 
 const SCHEMA_FILE_PATH = '.prisma/nearai-cloud.schema.prisma';

--- a/src/server/middlewares/route-resolver.ts
+++ b/src/server/middlewares/route-resolver.ts
@@ -11,7 +11,7 @@ import {
   ToUndefinedSchema,
   toUndefinedSchema,
 } from '../../types/route-resolver';
-import stream from 'node:stream';
+import stream from 'stream';
 
 export function createRouteResolver<
   TParamsInputSchema extends BaseSchema = ToUndefinedSchema,

--- a/src/server/routes/key/delete-key.ts
+++ b/src/server/routes/key/delete-key.ts
@@ -8,7 +8,7 @@ import { createOpenAiHttpError } from '../../../utils/error';
 import { Key } from '../../../types/litellm-api-client';
 
 const inputSchema = v.object({
-  keyHash: v.string(),
+  keyHash: v.pipe(v.string(), v.hash(['sha256'])),
 });
 
 export const deleteKey = createRouteResolver({

--- a/src/server/routes/key/delete-key.ts
+++ b/src/server/routes/key/delete-key.ts
@@ -11,21 +11,37 @@ import { createRouteResolver } from '../../middlewares/route-resolver';
 import { createOpenAiHttpError } from '../../../utils/error';
 import { Key } from '../../../types/litellm-api-client';
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const inputSchema = v.object({
   keyHash: v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE])),
 });
 
+/**
+ * @deprecated
+ */
+const inputSchemaLegacy = v.object({
+  keyOrKeyHash: v.optional(v.string()),
+  keyHash: v.optional(v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE]))),
+});
+
 export const deleteKey = createRouteResolver({
   inputs: {
-    body: inputSchema,
+    body: inputSchemaLegacy,
   },
   middlewares: [
     authMiddleware,
     async (req, res, next, { body }) => {
       const { user }: Auth = ctx.get(CTX_GLOBAL_KEYS.AUTH);
 
+      if (!body.keyHash && !body.keyOrKeyHash) {
+        throw createOpenAiHttpError({
+          status: STATUS_CODES.BAD_REQUEST,
+          message: 'Missing keyHash',
+        });
+      }
+
       const key = await adminLitellmApiClient.getKey({
-        keyOrKeyHash: body.keyHash,
+        keyOrKeyHash: body.keyHash ?? body.keyOrKeyHash!,
       });
 
       if (key && key.userId !== user.userId) {

--- a/src/server/routes/key/delete-key.ts
+++ b/src/server/routes/key/delete-key.ts
@@ -8,7 +8,7 @@ import { createOpenAiHttpError } from '../../../utils/error';
 import { Key } from '../../../types/litellm-api-client';
 
 const inputSchema = v.object({
-  keyOrKeyHash: v.string(),
+  keyHash: v.string(),
 });
 
 export const deleteKey = createRouteResolver({
@@ -21,7 +21,7 @@ export const deleteKey = createRouteResolver({
       const { user }: Auth = ctx.get(CTX_GLOBAL_KEYS.AUTH);
 
       const key = await adminLitellmApiClient.getKey({
-        keyOrKeyHash: body.keyOrKeyHash,
+        keyOrKeyHash: body.keyHash,
       });
 
       if (key && key.userId !== user.userId) {
@@ -42,7 +42,7 @@ export const deleteKey = createRouteResolver({
 
     if (key) {
       await adminLitellmApiClient.deleteKey({
-        keyOrKeyHashes: [key.keyOrKeyHash],
+        keyOrKeyHashes: [key.keyHash],
       });
     }
   },

--- a/src/server/routes/key/delete-key.ts
+++ b/src/server/routes/key/delete-key.ts
@@ -1,14 +1,18 @@
 import ctx from 'express-http-context';
 import * as v from 'valibot';
 import { adminLitellmApiClient } from '../../../services/litellm-api-client';
-import { CTX_GLOBAL_KEYS, STATUS_CODES } from '../../../utils/consts';
+import {
+  CTX_GLOBAL_KEYS,
+  INPUT_LIMITS,
+  STATUS_CODES,
+} from '../../../utils/consts';
 import { Auth, authMiddleware } from '../../middlewares/auth';
 import { createRouteResolver } from '../../middlewares/route-resolver';
 import { createOpenAiHttpError } from '../../../utils/error';
 import { Key } from '../../../types/litellm-api-client';
 
 const inputSchema = v.object({
-  keyHash: v.pipe(v.string(), v.hash(['sha256'])),
+  keyHash: v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE])),
 });
 
 export const deleteKey = createRouteResolver({

--- a/src/server/routes/key/get-key.ts
+++ b/src/server/routes/key/get-key.ts
@@ -12,12 +12,22 @@ import { createRouteResolver } from '../../middlewares/route-resolver';
 import { Key } from '../../../types/litellm-api-client';
 import { toShortKeyAlias } from '../../../utils/common';
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const inputSchema = v.object({
   keyHash: v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE])),
 });
 
+/**
+ * @deprecated
+ */
+const inputSchemaLegacy = v.object({
+  keyOrKeyHash: v.optional(v.string()),
+  keyHash: v.optional(v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE]))),
+});
+
 const outputSchema = v.nullable(
   v.object({
+    keyOrKeyHash: v.string(),
     keyHash: v.string(),
     keyName: v.string(),
     keyAlias: v.nullable(v.string()),
@@ -38,7 +48,7 @@ const outputSchema = v.nullable(
 
 export const getKey = createRouteResolver({
   inputs: {
-    query: inputSchema,
+    query: inputSchemaLegacy,
   },
   output: outputSchema,
   middlewares: [
@@ -46,8 +56,15 @@ export const getKey = createRouteResolver({
     async (req, res, next, { query }) => {
       const { user }: Auth = ctx.get(CTX_GLOBAL_KEYS.AUTH);
 
+      if (!query.keyHash && !query.keyOrKeyHash) {
+        throw createOpenAiHttpError({
+          status: STATUS_CODES.BAD_REQUEST,
+          message: 'Missing keyHash',
+        });
+      }
+
       const key = await adminLitellmApiClient.getKey({
-        keyOrKeyHash: query.keyHash,
+        keyOrKeyHash: query.keyHash ?? query.keyOrKeyHash!,
       });
 
       if (key && key.userId !== user.userId) {
@@ -70,6 +87,7 @@ export const getKey = createRouteResolver({
       return null;
     } else {
       return {
+        keyOrKeyHash: key.keyHash,
         keyHash: key.keyHash,
         keyName: key.keyName,
         keyAlias:

--- a/src/server/routes/key/get-key.ts
+++ b/src/server/routes/key/get-key.ts
@@ -1,7 +1,11 @@
 import ctx from 'express-http-context';
 import * as v from 'valibot';
 import { adminLitellmApiClient } from '../../../services/litellm-api-client';
-import { CTX_GLOBAL_KEYS, STATUS_CODES } from '../../../utils/consts';
+import {
+  CTX_GLOBAL_KEYS,
+  INPUT_LIMITS,
+  STATUS_CODES,
+} from '../../../utils/consts';
 import { Auth, authMiddleware } from '../../middlewares/auth';
 import { createOpenAiHttpError } from '../../../utils/error';
 import { createRouteResolver } from '../../middlewares/route-resolver';
@@ -9,7 +13,7 @@ import { Key } from '../../../types/litellm-api-client';
 import { toShortKeyAlias } from '../../../utils/common';
 
 const inputSchema = v.object({
-  keyHash: v.pipe(v.string(), v.hash(['sha256'])),
+  keyHash: v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE])),
 });
 
 const outputSchema = v.nullable(

--- a/src/server/routes/key/get-key.ts
+++ b/src/server/routes/key/get-key.ts
@@ -9,12 +9,12 @@ import { Key } from '../../../types/litellm-api-client';
 import { toShortKeyAlias } from '../../../utils/common';
 
 const inputSchema = v.object({
-  keyOrKeyHash: v.string(),
+  keyHash: v.string(),
 });
 
 const outputSchema = v.nullable(
   v.object({
-    keyOrKeyHash: v.string(),
+    keyHash: v.string(),
     keyName: v.string(),
     keyAlias: v.nullable(v.string()),
     spend: v.number(),
@@ -43,7 +43,7 @@ export const getKey = createRouteResolver({
       const { user }: Auth = ctx.get(CTX_GLOBAL_KEYS.AUTH);
 
       const key = await adminLitellmApiClient.getKey({
-        keyOrKeyHash: query.keyOrKeyHash,
+        keyOrKeyHash: query.keyHash,
       });
 
       if (key && key.userId !== user.userId) {
@@ -66,7 +66,7 @@ export const getKey = createRouteResolver({
       return null;
     } else {
       return {
-        keyOrKeyHash: key.keyOrKeyHash,
+        keyHash: key.keyHash,
         keyName: key.keyName,
         keyAlias:
           key.userId && key.keyAlias

--- a/src/server/routes/key/get-key.ts
+++ b/src/server/routes/key/get-key.ts
@@ -9,7 +9,7 @@ import { Key } from '../../../types/litellm-api-client';
 import { toShortKeyAlias } from '../../../utils/common';
 
 const inputSchema = v.object({
-  keyHash: v.string(),
+  keyHash: v.pipe(v.string(), v.hash(['sha256'])),
 });
 
 const outputSchema = v.nullable(

--- a/src/server/routes/key/get-spend-logs.ts
+++ b/src/server/routes/key/get-spend-logs.ts
@@ -6,7 +6,7 @@ import { Auth, authMiddleware } from '../../middlewares/auth';
 import { createRouteResolver } from '../../middlewares/route-resolver';
 
 const inputSchema = v.object({
-  keyHash: v.string(),
+  keyHash: v.pipe(v.string(), v.hash(['sha256'])),
   startDate: v.optional(v.pipe(v.string(), v.isoDate())),
   endDate: v.optional(v.pipe(v.string(), v.isoDate())),
 });

--- a/src/server/routes/key/get-spend-logs.ts
+++ b/src/server/routes/key/get-spend-logs.ts
@@ -6,7 +6,7 @@ import { Auth, authMiddleware } from '../../middlewares/auth';
 import { createRouteResolver } from '../../middlewares/route-resolver';
 
 const inputSchema = v.object({
-  keyOrKeyHash: v.string(),
+  keyHash: v.string(),
   startDate: v.optional(v.pipe(v.string(), v.isoDate())),
   endDate: v.optional(v.pipe(v.string(), v.isoDate())),
 });
@@ -39,7 +39,7 @@ export const getSpendLogs = createRouteResolver({
 
     const logs = await adminLitellmApiClient.getSpendLogs({
       userId: user.userId,
-      keyOrKeyHash: query.keyOrKeyHash,
+      keyOrKeyHash: query.keyHash,
       startDate: query.startDate,
       endDate: query.endDate,
     });

--- a/src/server/routes/key/get-spend-logs.ts
+++ b/src/server/routes/key/get-spend-logs.ts
@@ -1,12 +1,12 @@
 import ctx from 'express-http-context';
 import * as v from 'valibot';
 import { adminLitellmApiClient } from '../../../services/litellm-api-client';
-import { CTX_GLOBAL_KEYS } from '../../../utils/consts';
+import { CTX_GLOBAL_KEYS, INPUT_LIMITS } from '../../../utils/consts';
 import { Auth, authMiddleware } from '../../middlewares/auth';
 import { createRouteResolver } from '../../middlewares/route-resolver';
 
 const inputSchema = v.object({
-  keyHash: v.pipe(v.string(), v.hash(['sha256'])),
+  keyHash: v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE])),
   startDate: v.optional(v.pipe(v.string(), v.isoDate())),
   endDate: v.optional(v.pipe(v.string(), v.isoDate())),
 });

--- a/src/server/routes/key/get-spend-logs.ts
+++ b/src/server/routes/key/get-spend-logs.ts
@@ -22,7 +22,7 @@ const inputSchema = v.object({
  */
 const inputSchemaLegacy = v.object({
   keyOrKeyHash: v.optional(v.string()),
-  keyHash: v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE])),
+  keyHash: v.optional(v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE]))),
   startDate: v.optional(v.pipe(v.string(), v.isoDate())),
   endDate: v.optional(v.pipe(v.string(), v.isoDate())),
 });

--- a/src/server/routes/key/get-spend-logs.ts
+++ b/src/server/routes/key/get-spend-logs.ts
@@ -1,11 +1,27 @@
 import ctx from 'express-http-context';
 import * as v from 'valibot';
 import { adminLitellmApiClient } from '../../../services/litellm-api-client';
-import { CTX_GLOBAL_KEYS, INPUT_LIMITS } from '../../../utils/consts';
+import {
+  CTX_GLOBAL_KEYS,
+  INPUT_LIMITS,
+  STATUS_CODES,
+} from '../../../utils/consts';
 import { Auth, authMiddleware } from '../../middlewares/auth';
 import { createRouteResolver } from '../../middlewares/route-resolver';
+import { createOpenAiHttpError } from '../../../utils/error';
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const inputSchema = v.object({
+  keyHash: v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE])),
+  startDate: v.optional(v.pipe(v.string(), v.isoDate())),
+  endDate: v.optional(v.pipe(v.string(), v.isoDate())),
+});
+
+/**
+ * @deprecated
+ */
+const inputSchemaLegacy = v.object({
+  keyOrKeyHash: v.optional(v.string()),
   keyHash: v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE])),
   startDate: v.optional(v.pipe(v.string(), v.isoDate())),
   endDate: v.optional(v.pipe(v.string(), v.isoDate())),
@@ -30,16 +46,23 @@ const outputSchema = v.array(
 
 export const getSpendLogs = createRouteResolver({
   inputs: {
-    query: inputSchema,
+    query: inputSchemaLegacy,
   },
   output: outputSchema,
   middlewares: [authMiddleware],
   resolve: async ({ inputs: { query } }) => {
     const { user }: Auth = ctx.get(CTX_GLOBAL_KEYS.AUTH);
 
+    if (!query.keyHash && !query.keyOrKeyHash) {
+      throw createOpenAiHttpError({
+        status: STATUS_CODES.BAD_REQUEST,
+        message: 'Missing keyHash',
+      });
+    }
+
     const logs = await adminLitellmApiClient.getSpendLogs({
       userId: user.userId,
-      keyOrKeyHash: query.keyHash,
+      keyOrKeyHash: query.keyHash ?? query.keyOrKeyHash!,
       startDate: query.startDate,
       endDate: query.endDate,
     });

--- a/src/server/routes/key/list-keys.ts
+++ b/src/server/routes/key/list-keys.ts
@@ -29,7 +29,7 @@ const inputSchema = v.object({
 const outputSchema = v.object({
   keys: v.array(
     v.object({
-      keyOrKeyHash: v.string(),
+      keyHash: v.string(),
       keyName: v.string(),
       keyAlias: v.nullable(v.string()),
       spend: v.number(),

--- a/src/server/routes/key/list-keys.ts
+++ b/src/server/routes/key/list-keys.ts
@@ -29,6 +29,7 @@ const inputSchema = v.object({
 const outputSchema = v.object({
   keys: v.array(
     v.object({
+      keyOrKeyHash: v.string(),
       keyHash: v.string(),
       keyName: v.string(),
       keyAlias: v.nullable(v.string()),
@@ -77,6 +78,7 @@ export const listKeys = createRouteResolver({
             key.userId && key.keyAlias
               ? toShortKeyAlias(key.userId, key.keyAlias)
               : key.keyAlias,
+          keyOrKeyHash: key.keyHash,
         };
       }),
       totalKeys: keys.totalKeys,

--- a/src/server/routes/key/update-key.ts
+++ b/src/server/routes/key/update-key.ts
@@ -12,7 +12,7 @@ import { createOpenAiHttpError } from '../../../utils/error';
 import { toFullKeyAlias } from '../../../utils/common';
 
 const inputSchema = v.object({
-  keyHash: v.pipe(v.string(), v.hash(['sha256'])),
+  keyHash: v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE])),
   keyAlias: v.optional(
     v.pipe(v.string(), v.maxLength(INPUT_LIMITS.KEY_ALIAS_MAX_LENGTH)),
   ),

--- a/src/server/routes/key/update-key.ts
+++ b/src/server/routes/key/update-key.ts
@@ -12,7 +12,7 @@ import { createOpenAiHttpError } from '../../../utils/error';
 import { toFullKeyAlias } from '../../../utils/common';
 
 const inputSchema = v.object({
-  keyOrKeyHash: v.string(),
+  keyHash: v.string(),
   keyAlias: v.optional(
     v.pipe(v.string(), v.maxLength(INPUT_LIMITS.KEY_ALIAS_MAX_LENGTH)),
   ),
@@ -30,7 +30,7 @@ export const updateKey = createRouteResolver({
       const { user }: Auth = ctx.get(CTX_GLOBAL_KEYS.AUTH);
 
       const key = await adminLitellmApiClient.getKey({
-        keyOrKeyHash: body.keyOrKeyHash,
+        keyOrKeyHash: body.keyHash,
       });
 
       if (!key) {
@@ -55,7 +55,7 @@ export const updateKey = createRouteResolver({
     const { user }: Auth = ctx.get(CTX_GLOBAL_KEYS.AUTH);
 
     await adminLitellmApiClient.updateKey({
-      keyOrKeyHash: body.keyOrKeyHash,
+      keyOrKeyHash: body.keyHash,
       keyAlias: body.keyAlias
         ? toFullKeyAlias(user.userId, body.keyAlias)
         : undefined,

--- a/src/server/routes/key/update-key.ts
+++ b/src/server/routes/key/update-key.ts
@@ -12,7 +12,7 @@ import { createOpenAiHttpError } from '../../../utils/error';
 import { toFullKeyAlias } from '../../../utils/common';
 
 const inputSchema = v.object({
-  keyHash: v.string(),
+  keyHash: v.pipe(v.string(), v.hash(['sha256'])),
   keyAlias: v.optional(
     v.pipe(v.string(), v.maxLength(INPUT_LIMITS.KEY_ALIAS_MAX_LENGTH)),
   ),

--- a/src/server/routes/key/update-key.ts
+++ b/src/server/routes/key/update-key.ts
@@ -11,6 +11,7 @@ import { createRouteResolver } from '../../middlewares/route-resolver';
 import { createOpenAiHttpError } from '../../../utils/error';
 import { toFullKeyAlias } from '../../../utils/common';
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const inputSchema = v.object({
   keyHash: v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE])),
   keyAlias: v.optional(
@@ -20,17 +21,37 @@ const inputSchema = v.object({
   blocked: v.optional(v.boolean()),
 });
 
+/**
+ * @deprecated
+ */
+const inputSchemaLegacy = v.object({
+  keyOrKeyHash: v.optional(v.string()),
+  keyHash: v.optional(v.pipe(v.string(), v.hash([INPUT_LIMITS.KEY_HASH_TYPE]))),
+  keyAlias: v.optional(
+    v.pipe(v.string(), v.maxLength(INPUT_LIMITS.KEY_ALIAS_MAX_LENGTH)),
+  ),
+  maxBudget: v.optional(v.number()),
+  blocked: v.optional(v.boolean()),
+});
+
 export const updateKey = createRouteResolver({
   inputs: {
-    body: inputSchema,
+    body: inputSchemaLegacy,
   },
   middlewares: [
     authMiddleware,
     async (req, res, next, { body }) => {
       const { user }: Auth = ctx.get(CTX_GLOBAL_KEYS.AUTH);
 
+      if (!body.keyHash && !body.keyOrKeyHash) {
+        throw createOpenAiHttpError({
+          status: STATUS_CODES.BAD_REQUEST,
+          message: 'Missing keyHash',
+        });
+      }
+
       const key = await adminLitellmApiClient.getKey({
-        keyOrKeyHash: body.keyHash,
+        keyOrKeyHash: body.keyHash ?? body.keyOrKeyHash!,
       });
 
       if (!key) {
@@ -55,7 +76,7 @@ export const updateKey = createRouteResolver({
     const { user }: Auth = ctx.get(CTX_GLOBAL_KEYS.AUTH);
 
     await adminLitellmApiClient.updateKey({
-      keyOrKeyHash: body.keyHash,
+      keyOrKeyHash: body.keyHash ?? body.keyOrKeyHash!,
       keyAlias: body.keyAlias
         ? toFullKeyAlias(user.userId, body.keyAlias)
         : undefined,

--- a/src/server/routes/openai/chat-completions.ts
+++ b/src/server/routes/openai/chat-completions.ts
@@ -1,12 +1,12 @@
-import ctx from 'express-http-context';
-import { KeyAuth, keyAuthMiddleware } from '../../middlewares/auth';
-import { CTX_GLOBAL_KEYS } from '../../../utils/consts';
+import { BEARER_TOKEN_PREFIX } from '../../../utils/consts';
 import { createRouteResolver } from '../../middlewares/route-resolver';
+import { createLitellmApiClient } from '../../../services/litellm-api-client';
 
 export const chatCompletions = createRouteResolver({
-  middlewares: [keyAuthMiddleware],
   resolve: async ({ req }) => {
-    const { litellmApiClient }: KeyAuth = ctx.get(CTX_GLOBAL_KEYS.KEY_AUTH);
+    const litellmApiClient = createLitellmApiClient(
+      req.headers.authorization?.slice(BEARER_TOKEN_PREFIX.length) ?? '',
+    );
     return litellmApiClient.chatCompletions(req.body);
   },
 });

--- a/src/server/routes/openai/models.ts
+++ b/src/server/routes/openai/models.ts
@@ -1,12 +1,12 @@
-import ctx from 'express-http-context';
-import { KeyAuth, keyAuthMiddleware } from '../../middlewares/auth';
-import { CTX_GLOBAL_KEYS } from '../../../utils/consts';
+import { BEARER_TOKEN_PREFIX } from '../../../utils/consts';
 import { createRouteResolver } from '../../middlewares/route-resolver';
+import { createLitellmApiClient } from '../../../services/litellm-api-client';
 
 export const models = createRouteResolver({
-  middlewares: [keyAuthMiddleware],
-  resolve: async () => {
-    const { litellmApiClient }: KeyAuth = ctx.get(CTX_GLOBAL_KEYS.KEY_AUTH);
+  resolve: async ({ req }) => {
+    const litellmApiClient = createLitellmApiClient(
+      req.headers.authorization?.slice(BEARER_TOKEN_PREFIX.length) ?? '',
+    );
     return litellmApiClient.models();
   },
 });

--- a/src/types/litellm-api-client.ts
+++ b/src/types/litellm-api-client.ts
@@ -53,7 +53,7 @@ export type GetKeyParams = {
 };
 
 export type Key = {
-  keyOrKeyHash: string;
+  keyHash: string;
   keyName: string; // Simplified key string. e.g. sk-...ABcd
   keyAlias: string | null;
   spend: number;

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -5,6 +5,7 @@ export const BEARER_TOKEN_PREFIX = 'Bearer ';
 export const LITELLM_KEY_PREFIX = 'sk-';
 
 export const INPUT_LIMITS = {
+  KEY_HASH_TYPE: 'sha256',
   KEY_ALIAS_MAX_LENGTH: 256,
   MIN_PAGE: 1,
   MIN_PAGE_SIZE: 1,

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -2,6 +2,8 @@ export const SLACK_ALERT_TAG = 'nearai-cloud-server';
 
 export const BEARER_TOKEN_PREFIX = 'Bearer ';
 
+export const LITELLM_KEY_PREFIX = 'sk-';
+
 export const INPUT_LIMITS = {
   KEY_ALIAS_MAX_LENGTH: 256,
   MIN_PAGE: 1,

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,6 +1,15 @@
 import { createHash } from 'crypto';
 import nacl from 'tweetnacl';
 import { config } from '../config';
+import { LITELLM_KEY_PREFIX } from './consts';
+
+export function litellmKeyHash(keyOrKeyHash: string): string {
+  if (keyOrKeyHash.startsWith(LITELLM_KEY_PREFIX)) {
+    return createHash('sha256').update(keyOrKeyHash).digest().toString('hex');
+  } else {
+    return keyOrKeyHash;
+  }
+}
 
 export function litellmDecryptValue(
   valueBase64: string,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keys are now shown and handled as hashed identifiers (keyHash) across listings, details, updates, deletions, and spend logs.
  * get-key response now includes extra metadata: expiration, user ID, rate limits, budget details, blocked status, creation time, and custom metadata.

* **Refactor**
  * Routes accept both legacy and hashed key inputs for backward compatibility, with validation errors when missing.
  * OpenAI-related routes now use Bearer token from the Authorization header for requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->