### PR TITLE
fix: error message when update non-existent credentials

### DIFF
--- a/src/services/litellm-api-client.ts
+++ b/src/services/litellm-api-client.ts
@@ -1030,8 +1030,10 @@ export class LitellmApiClient extends ApiClient {
     providerApiUrl,
     providerApiKey,
   }: UpdateCredentialParams) {
-    await this.patch<
-      void,
+    const res = await this.patch<
+      void | {
+        openai_code: 404;
+      },
       {
         credential_name: string;
         credential_info?: {
@@ -1055,6 +1057,14 @@ export class LitellmApiClient extends ApiClient {
         },
       },
     });
+
+    // TODO: Issue of LiteLLM
+    if (res && 'openai_code' in res && res.openai_code === 404) {
+      throw new ApiError({
+        status: STATUS_CODES.BAD_REQUEST,
+        message: 'Cannot update a credential that not exists',
+      });
+    }
   }
 
   private getModelsCache(

--- a/src/services/litellm-api-client.ts
+++ b/src/services/litellm-api-client.ts
@@ -1062,7 +1062,7 @@ export class LitellmApiClient extends ApiClient {
     if (res && 'openai_code' in res && res.openai_code === 404) {
       throw new ApiError({
         status: STATUS_CODES.BAD_REQUEST,
-        message: 'Cannot update a credential that not exists',
+        message: 'Cannot update a credential that does not exist',
       });
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a credential that doesn’t exist now reliably returns a clear, actionable 400 error instead of appearing to succeed or failing silently.
  * Credential update error handling is more consistent, making it easier to diagnose and resolve configuration issues.
  * Valid credential updates remain unchanged and continue to succeed as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->